### PR TITLE
Add separator when there are more than 2 elements

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -22,7 +22,6 @@
           <h1>{{ this.title }}</h1></div>
         </div>
     </div>
-  
     {%- set crumbs = [] -%}
     {%- set current = {'crumb': this} -%}
     {%- for i in this._path.split("/") -%}
@@ -37,6 +36,7 @@
             {%- set name = crumb.title if crumb.title else crumb.name + ' ' + last_name -%}
             > {{ name }}
         {%- else -%}
+            {%- if loop.index != 1 -%}>{%- endif -%}
             <a href="{{ crumb|url }}">{{ crumb.title }} </a>
         {%- endif -%}
     {%- endfor -%}


### PR DESCRIPTION
Change this:
<img width="654" alt="screen shot 2018-07-30 at 7 12 49 pm" src="https://user-images.githubusercontent.com/5531776/43430237-8019b8c0-942d-11e8-8f10-4871677c196e.png">

To this:
![image](https://user-images.githubusercontent.com/5531776/43430246-8a5679cc-942d-11e8-8aea-0acb838e6d25.png)

Not much of an improvement, but should look (and work) better.