### PR TITLE
Modificado formato de título para las vistas en el navegador

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -13,7 +13,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
   <meta name="description" content="Sitio web de la comunidad de Python Colombia">
   <meta name="author" content="Python Colombia">
-  <title>{% block title %}{{ this.title }}{% endblock %}</title>
+  <title>{% block title %}{% if this._path == '/' %} Inicio {% else %} {{ this.title }} {% endif %}{% endblock %} | Python Colombia</title>
   <!-- Favicon -->
   <link rel="shortcut icon" type="image/x-icon" href="{{ base_url }}static/images/favicon.png" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css" integrity="sha512-Rksm5RenBEKSKFjgI3a41vrjkw4EVPlJ3+OiI65vTjIdo9brlAacEuKOiQ5OFh7cOI1bkDwLqdLw3Zg0cRJAAQ==" crossorigin="" />


### PR DESCRIPTION
fixes #111

Formato:
```html
<title>{% block title %}{% if this._path == '/' %} Inicio {% else %} {{ this.title }} {% endif %}{% endblock %} | Python Colombia</title>
```